### PR TITLE
Adding option to skip token validation.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,13 +97,19 @@ module.exports = function(options) {
         }
       },
       function verifyToken(secret, callback) {
-        jwt.verify(token, secret, options, function(err, decoded) {
-          if (err) {
-            callback(new UnauthorizedError('invalid_token', err));
-          } else {
-            callback(null, decoded);
-          }
-        });
+        if (options.skipVerify) {
+          var payload = dtoken.payload;
+          payload.unverified = true;
+          callback(null, payload);
+        } else {
+          jwt.verify(token, secret, options, function(err, decoded) {
+            if (err) {
+              callback(new UnauthorizedError('invalid_token', err));
+            } else {
+              callback(null, decoded);
+            }
+          });
+        }
       },
       function checkRevoked(decoded, callback) {
         isRevokedCallback(req, dtoken.payload, function (err, revoked) {


### PR DESCRIPTION
Looks for `skipVerify` in options.

```

jwtAuth({
  secret: yoursupersecret,
  skipVerify: true
})

```

Appends `unverified: true` to decoded token data (saved to `req.user` by default).

Resolves #183